### PR TITLE
use htmlspecialchars around data['search'] to address #104

### DIFF
--- a/Tweeki.skin.php
+++ b/Tweeki.skin.php
@@ -1107,7 +1107,7 @@ class TweekiTemplate extends BaseTemplate {
 		$skin->text('searchtitle');
 		echo '" placeholder="';
 		$skin->msg('search');
-		echo '" name="search" value="' . $this->text['search'] .'">
+		echo '" name="search" value="' . htmlspecialchars($this->data['search']) .'">
 					' . $skin->makeSearchButton( 'go', array( 'id' => 'mw-searchButton', 'class' => 'searchButton btn hidden' ) ) . '
 				</div>
 			</form>';

--- a/Tweeki.skin.php
+++ b/Tweeki.skin.php
@@ -1107,7 +1107,7 @@ class TweekiTemplate extends BaseTemplate {
 		$skin->text('searchtitle');
 		echo '" placeholder="';
 		$skin->msg('search');
-		echo '" name="search" value="' . $this->data['search'] .'">
+		echo '" name="search" value="' . $this->text['search'] .'">
 					' . $skin->makeSearchButton( 'go', array( 'id' => 'mw-searchButton', 'class' => 'searchButton btn hidden' ) ) . '
 				</div>
 			</form>';


### PR DESCRIPTION
To fix XSS issue, calls `htmlspecialchars` explicitly. I don't know if there are further changes necessary for related bugs, but this was the only apparent use of data['search'] in an unescaped way.