### PR TITLE
Add code to correct VisualEditor toolbar scrolling

### DIFF
--- a/tweeki.js
+++ b/tweeki.js
@@ -103,4 +103,34 @@ jQuery( function( $ ) {
 			setTimeout( '$( "#wpName2" ).focus();', 100 );
 			}
 		});
+
+        /**
+         * Fix VisualEditor scroll stickiness
+         *
+         * Had to use the child-parent methods below because the oo-ui-toolbar-bar
+         * class exists on multiple divs.
+         *
+         * The code calculates the navbar height and uses that number as the 'top'
+         * CSS attribute. This calculation is probably moot as it doesn't appear
+         * that the skin, or VisualEditor plays well on screen resolutions less
+         * than 1024 pixels wide. Left the code this way in case something with
+         * VE changes in the future.
+         *
+         **/
+         $(window).scroll( function ( e ) {
+                 // Check to see if the navbar-fixed-top class exists. If it
+                 // does then the navbar is fixed and run this code if
+                 if ( $( '.navbar-fixed-top').length ) {
+                         var $el = $('.oo-ui-toolbar-bar > .oo-ui-toolbar-actions');
+                         var $headerheight = $('#mw-head').height();
+                         var isPositionFixed = ($el.parent().css('position') == 'fixed');
+                         if ($(this).scrollTop() > $headerheight && !isPositionFixed){
+                                 $el.parent().css( 'top', $headerheight );
+                         }
+                         if ($(this).scrollTop() < $headerheight )
+                         {
+                                 $el.parent().css( 'top', '');
+                         }
+                 }
+              });
 	});


### PR DESCRIPTION
When the Tweeki navbar is fixed to the top of the page and the VisualEditor extension is installed, the VE toolbar scrolls underneath the navbar. This JS code adds a 'top' CSS style the height of the navbar in pixels so that the VE toolbar stays visible.

There may be a more "correct" or efficient method of accomplishing this task but this WorksForMe® 😄 

Let me know if anyone has questions.

Tested with the following versions:


Product | Version
-- | --
MediaWiki | 1.30.0 (830bb58)
PHP | 7.0.30 (apache2handler)
MariaDB | 5.5.56-MariaDB
ICU | 50.1.2
Elasticsearch | 5.6.9


Extension | Version | License | Description | Authors
-- | -- | -- | -- | --
VisualEditor | 0.1.0 (61f161a)2017-10-02T13:07:41 | MIT | Visual editor for MediaWiki | Alex Monk, Bartosz Dziewoński, Christian Williams, Ed Sanders, Inez Korczyński, James D. Forrester, Moriel Schottlender, Roan Kattouw, Rob Moen, Timo Tijhof, Trevor Parscal, C. Scott Ananian and others


