### PR TITLE
Fixed namespace logic

### DIFF
--- a/includes/TweekiTemplate.php
+++ b/includes/TweekiTemplate.php
@@ -71,7 +71,7 @@ class TweekiTemplate extends BaseTemplate {
 		$this->data['namespace'] = str_replace( "_", " ", $this->getSkin()->getTitle()->getNsText() );
 		$this->data['title_formatted'] = $this->data['title'];
 		if( $this->data['namespace'] !== '') {
-			$this->data['title_formatted'] = '<span class="namespace">' . $this->data['namespace'] . ":</span> " . $this->getSkin()->getTitle()->getBaseText();
+			$this->data['title_formatted'] = '<span class="namespace">' . $this->data['namespace'] . ":</span> " . $this->getSkin()->getTitle()->getText();
 		}
 
 		// Output HTML Page

--- a/includes/TweekiTemplate.php
+++ b/includes/TweekiTemplate.php
@@ -68,10 +68,10 @@ class TweekiTemplate extends BaseTemplate {
 		}
 		
 		//set 'namespace' and 'title_formatted' variables
-		$this->data['namespace'] = $this->getSkin()->getTitle()->getNsText();
+		$this->data['namespace'] = str_replace( "_", " ", $this->getSkin()->getTitle()->getNsText() );
 		$this->data['title_formatted'] = $this->data['title'];
-		if( strpos( $this->data['title'], $this->data['namespace'] . ":" ) !== false ) { 
-			$this->data['title_formatted'] = '<span class="namespace">' . str_replace( ":", ":</span> ", $this->data['title'] );
+		if( $this->data['namespace'] !== '') {
+			$this->data['title_formatted'] = '<span class="namespace">' . $this->data['namespace'] . ":</span> " . $this->getSkin()->getTitle()->getBaseText();
 		}
 
 		// Output HTML Page


### PR DESCRIPTION
Fixes three bugs:
1) Namespaces are rendered with underscores rather than spaces on the edit button.
2) Namespaces with underscores are not wrapped with `<span class="namespace">`
3) In titles with colons, all text before the colon is styled as a namespace.