### PR TITLE
Check for MagicWord::get() before using

### DIFF
--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -1,4 +1,7 @@
 <?php
+
+use MediaWiki\MediaWikiServices;
+
 /**
  * Hooks for Tweeki skin
  *
@@ -16,7 +19,7 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  * http://www.gnu.org/copyleft/gpl.html
- * 
+ *
  * @file
  * @ingroup Skins
  */
@@ -85,13 +88,13 @@ class TweekiHooks {
 			}
 		}
 	}
-	
+
 	/**
 	 * Customizing registration
 	 */
 	public static function onRegistration() {
 		global $wgTweekiSkinCustomizedBootstrap, $wgResourceModules;
-	
+
 		/* Load customized bootstrap files */
 		if( isset( $wgTweekiSkinCustomizedBootstrap ) && ! is_null( $wgTweekiSkinCustomizedBootstrap ) ) {
 			$wgResourceModules['skins.tweeki.bootstrap.styles']['localBasePath'] = $wgTweekiSkinCustomizedBootstrap['localBasePath'];
@@ -304,24 +307,24 @@ class TweekiHooks {
 
 		foreach ( $lines as $line ) {
 			// empty line
-			if ( trim( $line ) == "" ) { 
+			if ( trim( $line ) == "" ) {
 				continue;
 			}
-			
+
 			// simple buttons
 			if ( strpos( $line, '*' ) !== 0 ) {
 				$buttons = array_merge( $buttons, TweekiHooks::parseButtonLink( trim( $line ), $parser, $frame ) );
 				end( $buttons );
 				$currentparentkey = key($buttons);
 			}
-				
+
 			// dropdown menus
 			else {
 				// no parent set?
 				if ( count( $buttons ) == 0 ) {
 					continue;
 				}
-				
+
 				$cleanline = ltrim( $line, '*' );
 				$cleanline = trim( $cleanline );
 				if ( !isset( $buttons[$currentparentkey]['items'] ) ) {
@@ -353,7 +356,7 @@ class TweekiHooks {
 		$extraAttribs = array();
 		$href_implicit = false;
 		$active = false;
-				
+
 		// semantic queries
 		if ( strpos( $line, '{{#ask:' ) === 0 ) {
 			if ( $parser->getTitle() instanceof Title ) {
@@ -482,7 +485,7 @@ class TweekiHooks {
 
 		// set wrapper
 		$wrapper = 'div';
-		if ( isset( $options['wrapper'] ) ) { 
+		if ( isset( $options['wrapper'] ) ) {
 			$wrapper = $options['wrapper'];
 		}
 
@@ -522,26 +525,26 @@ class TweekiHooks {
 			if ( isset( $options['aria-controls'] ) ) {
 				$button['aria-controls'] = $options['aria-controls'];
 			}
-				
+
 			if ( isset( $options['aria-expanded'] ) ) {
 				$button['aria-expanded'] = $options['aria-expanded'];
 			}
-				
+
 			// if data-target attribute is set, add it
 			if ( isset( $options['data-target'] ) ) {
 				$button['data-target'] = $options['data-target'];
 			}
-				
+
 			// if data-dismiss attribute is set, add it
 			if ( isset( $options['data-dismiss'] ) ) {
 				$button['data-dismiss'] = $options['data-dismiss'];
 			}
-				
+
 			// if data-placement attribute is set, add it
 			if ( isset( $options['data-placement'] ) ) {
 				$button['data-placement'] = $options['data-placement'];
 			}
-				
+
 			// if data-slide attribute is set, add it
 			if ( isset( $options['data-slide'] ) ) {
 				$button['data-slide'] = $options['data-slide'];
@@ -551,14 +554,14 @@ class TweekiHooks {
 			if ( isset( $options['title'] ) ) {
 				$button['title'] = $options['title'];
 			}
-				
+
 			// if data-toggle attribute is set, unset wrapper and add attribute and toggle-class
 			if ( isset( $options['data-toggle'] ) ) {
 				$wrapper = '';
 				$button['data-toggle'] = $options['data-toggle'];
 				$button['class'] .= ' ' . $options['data-toggle'] . '-toggle';
 			}
-			
+
 			// if html is not set, use text and sanitize it
 			if ( !isset( $button['html'] ) ) {
 				if( isset( $button['text'] ) ) {
@@ -568,7 +571,7 @@ class TweekiHooks {
 					$button['html'] = '#';
 				}
 			}
-			
+
 			// if fa attribute is set, add fa-icon to buttons
 			if ( isset( $options['fa'] ) ) {
 				$button['html'] = '<span class="fa fa-' . $options['fa'] . '"></span> ' . $button['html'];
@@ -583,9 +586,9 @@ class TweekiHooks {
 			}
 
 			// render wrapper
-			if ( 
-				( ( $currentwrapperclass != $wrapperclass || isset( $button['items'] ) ) && $wrapper != '' ) 
-				|| $wrapper == 'li' 
+			if (
+				( ( $currentwrapperclass != $wrapperclass || isset( $button['items'] ) ) && $wrapper != '' )
+				|| $wrapper == 'li'
 			) {
 				if ( $currentwrapperclass != '' ) {
 					$renderedButtons .= '</' . $wrapper . '>';
@@ -695,7 +698,7 @@ class TweekiHooks {
 
 	/**
 	 * Produce HTML for a link
-	 * 
+	 *
 	 * This is a slightly adapted copy of the makeLink function in SkinTemplate.php
 	 * -> some of the changed parts are marked by comments //
 	 *
@@ -795,7 +798,7 @@ class TweekiHooks {
 
 	/**
 	 * Produce HTML for a list item
-	 * 
+	 *
 	 * This is a slightly adapted copy of the makeListItem function in SkinTemplate.php
 	 * -> some of the changed parts are marked by comments //
 	 *
@@ -852,9 +855,9 @@ class TweekiHooks {
 	 * @todo: make this work with VisualEditor
 	 */
 	static function onSkinEditSectionLinks( $skin, $title, $section, $tooltip, &$links, $lang = false ) {
-		if( 
-			$skin->getSkinName() == 'tweeki' 
-			&& $GLOBALS['wgTweekiSkinCustomEditSectionLink'] == true 
+		if(
+			$skin->getSkinName() == 'tweeki'
+			&& $GLOBALS['wgTweekiSkinCustomEditSectionLink'] == true
 		) {
 			$icon = wfMessage( 'tweeki-editsection-icon' )->inLanguage( $lang )->parse();
 			$text = wfMessage( 'tweeki-editsection-text' )->inLanguage( $lang )->parse();
@@ -892,8 +895,8 @@ class TweekiHooks {
 		return true;
 	}
 
-	/** 
-	 * 
+	/**
+	 *
 	 */
 	public static function onMagicWordMagicWords( &$magicWords ) {
 		$magicWords[] = 'MAG_NUMBEREDHEADINGS';
@@ -906,7 +909,17 @@ class TweekiHooks {
 	}
 
 	public static function onInternalParseBeforeLinks( &$parser, &$text, &$strip_state ) {
-		if ( MagicWord::get( 'MAG_NUMBEREDHEADINGS' )->matchAndRemove( $text ) ) {
+		$id = 'MAG_NUMBEREDHEADINGS';
+		if ( method_exists( MagicWord::class, 'get' ) ) {
+			// Before 1.35.
+			$magicWord = MagicWord::get( $id );
+		} else {
+			// 1.35 and above.
+			$magicWord = MediaWikiServices::getInstance()
+				->getMagicWordFactory()
+				->get( $id );
+		}
+		if ( $magicWord->matchAndRemove( $text ) ) {
 			$parser->mOptions->setNumberHeadings( true );
 		}
 		return true;


### PR DESCRIPTION
This method has been removed in MediaWiki 1.35.

Also remove trailing spaces on lines in the Hooks class.