### PR TITLE
Use hook to add body attributes

### DIFF
--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -924,5 +924,13 @@ class TweekiHooks {
 		}
 		return true;
 	}
+	
+	public static function onOutputPageBodyAttributes( $out, $sk, &$bodyAttrs ) {
+		if ( isset( $bodyAttrs['class'] ) && strlen( $bodyAttrs['class'] ) > 0 ) {
+			$bodyAttrs['class'] .= ' ' . implode( ' ', SkinTweeki::$bodyClasses );
+		} else {
+			$bodyAttrs['class'] = implode( ' ', SkinTweeki::$bodyClasses );
+		}
+	}
 
 }

--- a/includes/SkinTweeki.php
+++ b/includes/SkinTweeki.php
@@ -42,7 +42,7 @@ class SkinTweeki extends SkinTemplate {
 			->makeConfig( 'tweeki' );
 	}
 
-	protected static $bodyClasses = array( 'tweeki-animateLayout' );
+	public static $bodyClasses = array( 'tweeki-animateLayout' );
 
 
 	/**
@@ -87,21 +87,7 @@ class SkinTweeki extends SkinTemplate {
 		Hooks::run( 'SkinTweekiStyleModules', array( $this, &$styles ) );
 		$out->addModuleStyles( $styles );
 	}
-
-	/**
-	 * Adds classes to the body element.
-	 *
-	 * @param $out OutputPage object
-	 * @param &$bodyAttrs Array of attributes that will be set on the body element
-	 */
-	function addToBodyAttributes( $out, &$bodyAttrs ) {
-		if ( isset( $bodyAttrs['class'] ) && strlen( $bodyAttrs['class'] ) > 0 ) {
-			$bodyAttrs['class'] .= ' ' . implode( ' ', static::$bodyClasses );
-		} else {
-			$bodyAttrs['class'] = implode( ' ', static::$bodyClasses );
-		}
-	}
-
+	
 	/**
 	 * Override to pass our Config instance to it
 	 * @param string $classname

--- a/skin.json
+++ b/skin.json
@@ -37,7 +37,8 @@
 		"MagicWordMagicWords": "TweekiHooks::onMagicWordMagicWords",
 		"MagicWordwgVariableIDs": "TweekiHooks::onMagicWordwgVariableIDs",
 		"InternalParseBeforeLinks": "TweekiHooks::onInternalParseBeforeLinks",
-		"OutputPageBeforeHTML": "TweekiHooks::onOutputPageBeforeHTML"
+		"OutputPageBeforeHTML": "TweekiHooks::onOutputPageBeforeHTML",
+		"OutputPageBodyAttributes": "TweekiHooks::onOutputPageBodyAttributes"
 	},
 	"ResourceModules": {
 		"skins.tweeki.bootstrap.styles": {


### PR DESCRIPTION
OutputPageBodyAttributes hook and Skin::addToBodyAttributes( ) are both utilized to add more body attributes to the OutputPage object by extensions. Using the method is now deprecated and will emit deprecation warnings in MediaWiki 1.35.  

The recommend way to add them now is by using the OutputPageBodyAttributes hook only.