### PR TITLE
Remove deprecated `background-image-svg()` mixin calls

### DIFF
--- a/components/watchstar.less
+++ b/components/watchstar.less
@@ -19,22 +19,22 @@
 	background-repeat: no-repeat;
 }
 #ca-unwatch.icon a {
-	.background-image-svg( 'images/unwatch-icon.svg', 'images/unwatch-icon.png' );
+	background-image: url( images/unwatch-icon.svg );
 }
 #ca-watch.icon a {
-	.background-image-svg( 'images/watch-icon.svg', 'images/watch-icon.png' );
+	background-image: url( images/watch-icon.svg );
 }
 #ca-unwatch.icon a:hover,
 #ca-unwatch.icon a:focus {
-	.background-image-svg( 'images/unwatch-icon-hl.svg', 'images/unwatch-icon-hl.png' );
+	background-image: url( images/unwatch-icon-hl.svg );
 }
 #ca-watch.icon a:hover,
 #ca-watch.icon a:focus {
-	.background-image-svg( 'images/watch-icon-hl.svg', 'images/watch-icon-hl.png' );
+	background-image: url( images/watch-icon-hl.svg );
 }
 #ca-unwatch.icon a.loading,
 #ca-watch.icon a.loading {
-	.background-image-svg( 'images/watch-icon-loading.svg', 'images/watch-icon-loading.png' );
+	background-image: url( images/watch-icon-loading.svg );
 	.rotation( 700ms );
 	/* Suppress the hilarious rotating focus outline on Firefox */
 	outline: 0;


### PR DESCRIPTION
Deprecated in MW 1.35 and to be removed in MW 1.36.
See https://phabricator.wikimedia.org/T248062 for more information.