### PR TITLE
Fix checking for skin within onParserFirstCallInit

### DIFF
--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -29,6 +29,10 @@ class TweekiHooks {
 	protected static $anchorID = 0;
 	protected static $realnames = [];
 
+	static function getSkinTweekiSkin() {
+		return $GLOBALS['wgOut']->getSkin()->getSkinName() === 'tweeki';
+	}
+
 	/**
 	 * Is this Wiki configured to use Bootstrap 4?
 	 */
@@ -49,22 +53,20 @@ class TweekiHooks {
 	 * @param $parser Parser current parser
 	 */
 	static function onParserFirstCallInit( Parser $parser ) {
-		if( $GLOBALS['wgOut']->getSkin()->getSkinName() == 'tweeki' ) {
-			$parser->setHook( 'TOC', 'TweekiHooks::TOC' );
-			$parser->setHook( 'legend', 'TweekiHooks::legend' );
-			$parser->setHook( 'footer', 'TweekiHooks::footer' );
-			$parser->setHook( 'accordion', 'TweekiHooks::buildAccordion' );
-			$parser->setHook( 'label', 'TweekiHooks::buildLabel' );
+		$parser->setHook( 'TOC', 'TweekiHooks::TOC' );
+		$parser->setHook( 'legend', 'TweekiHooks::legend' );
+		$parser->setHook( 'footer', 'TweekiHooks::footer' );
+		$parser->setHook( 'accordion', 'TweekiHooks::buildAccordion' );
+		$parser->setHook( 'label', 'TweekiHooks::buildLabel' );
 
-			if ( true === $GLOBALS['wgTweekiSkinUseBtnParser'] ) {
-				$parser->setHook( 'btn', 'TweekiHooks::buildButtons' );
-			}
-
-			$parser->setFunctionHook( 'tweekihide', 'TweekiHooks::setHiddenElements' );
-			$parser->setFunctionHook( 'tweekihideexcept', 'TweekiHooks::setHiddenElementsGroups' );
-			$parser->setFunctionHook( 'tweekibodyclass', 'TweekiHooks::addBodyclass' );
-			$parser->setFunctionHook( 'tweekirealname', 'TweekiHooks::renderRealname' );
+		if ( $GLOBALS['wgTweekiSkinUseBtnParser'] === true ) {
+			$parser->setHook( 'btn', 'TweekiHooks::buildButtons' );
 		}
+
+		$parser->setFunctionHook( 'tweekihide', 'TweekiHooks::setHiddenElements' );
+		$parser->setFunctionHook( 'tweekihideexcept', 'TweekiHooks::setHiddenElementsGroups' );
+		$parser->setFunctionHook( 'tweekibodyclass', 'TweekiHooks::addBodyclass' );
+		$parser->setFunctionHook( 'tweekirealname', 'TweekiHooks::renderRealname' );
 
 		return true;
 	}
@@ -278,6 +280,9 @@ class TweekiHooks {
 	 * Enable TOC
 	 */
 	static function TOC( $input, array $args, Parser $parser, PPFrame $frame ) {
+		if ( !self::getSkinTweekiSkin() ) {
+			return [];
+		}
 		return [ '<div class="tweeki-toc">' . $parser->recursiveTagParse( $input ) . '</div>' ];
 	}
 
@@ -285,6 +290,9 @@ class TweekiHooks {
 	 * Enable use of <legend> tag
 	 */
 	static function legend( $input, array $args, Parser $parser, PPFrame $frame ) {
+		if ( !self::getSkinTweekiSkin() ) {
+			return [];
+		}
 		return [ '<legend>' . $parser->recursiveTagParse( $input ) . '</legend>', "markerType" => 'nowiki' ];
 	}
 
@@ -292,6 +300,9 @@ class TweekiHooks {
 	 * Enable use of <footer> tag
 	 */
 	static function footer( $input, array $args, Parser $parser, PPFrame $frame ) {
+		if ( !self::getSkinTweekiSkin() ) {
+			return [];
+		}
 		return [ '<footer>' . $parser->recursiveTagParse( $input ) . '</footer>', "markerType" => 'nowiki' ];
 	}
 
@@ -303,6 +314,10 @@ class TweekiHooks {
 	 */
 	static function setHiddenElements( Parser $parser ) {
 		global $wgTweekiSkinHideAll, $wgTweekiSkinHideable;
+
+		if ( !self::getSkinTweekiSkin() ) {
+			return '';
+		}
 
 		$parser->getOutput()->updateCacheExpiry(0);
 
@@ -322,6 +337,10 @@ class TweekiHooks {
 	 */
 	static function setHiddenElementsGroups( Parser $parser ) {
 		global $wgTweekiSkinHideAll, $wgTweekiSkinHideable;
+
+		if ( !self::getSkinTweekiSkin() ) {
+			return '';
+		}
 
 		$parser->getOutput()->updateCacheExpiry(0);
 
@@ -344,6 +363,10 @@ class TweekiHooks {
 	 * @return string
 	 */
 	static function addBodyclass( Parser $parser ) {
+		if ( !self::getSkinTweekiSkin() ) {
+			return '';
+		}
+
 		$parser->getOutput()->updateCacheExpiry(0);
 
 		for ( $i = 1; $i < func_num_args(); $i++ ) {
@@ -362,6 +385,9 @@ class TweekiHooks {
 	 * @return string
 	 */
 	static function buildAccordion( $input, array $args, Parser $parser, PPFrame $frame ) {
+		if ( !self::getSkinTweekiSkin() ) {
+			return '';
+		}
 		static::$anchorID++;
 		$parent = $parser->recursiveTagParse( $args['parent'], $frame );
 		if( ! self::isBS4() ) {
@@ -407,6 +433,9 @@ class TweekiHooks {
 	 * @return string
 	 */
 	static function buildLabel( $input, array $args, Parser $parser, PPFrame $frame ) {
+		if ( !self::getSkinTweekiSkin() ) {
+			return '';
+		}
 		return '<label>' . $parser->recursiveTagParse( $input ) . '</label>';
 	}
 
@@ -420,6 +449,10 @@ class TweekiHooks {
 	 * @return string
 	 */
 	static function buildButtons( $input, array $args, Parser $parser, PPFrame $frame ) {
+		if ( !self::getSkinTweekiSkin() ) {
+			return '';
+		}
+
 		$sizes = [
 			'large' => 'btn-lg',
 			'lg' => 'btn-lg',
@@ -673,6 +706,10 @@ class TweekiHooks {
 	 * @return String User's real name
 	 */
 	static function renderRealName( $parser, $user ) {
+		if ( !self::getSkinTweekiSkin() ) {
+			return [];
+		}
+
 		$realname = self::getRealname( $user );
 
 		return [ $realname ];


### PR DESCRIPTION
For some reason using wgOut within onParserFirstCallInit broke the skin preference for users.

To fix this we do the checking within the functions the parser calls.