### PR TITLE
Replace calls to removed/deprecated functions

### DIFF
--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -121,7 +121,8 @@ class TweekiHooks {
 				$styles[] = $customstyle;
 			}
 
-			Hooks::run( 'SkinTweekiStyleModules', [ $skin, &$styles ] );
+			$hookContainer = MediaWikiServices::getInstance()->getHookContainer();
+			$hookContainer->run( 'SkinTweekiStyleModules', [ $skin, &$styles ] );
 
 			$out->addModuleStyles( $styles );
 		}
@@ -180,7 +181,8 @@ class TweekiHooks {
 			
 			$additionalBodyClasses = array_merge( $additionalBodyClasses, $GLOBALS['wgTweekiSkinAdditionalBodyClasses'] );
 
-			Hooks::run( 'SkinTweekiAdditionalBodyClasses', [ $sk, &$additionalBodyClasses ] );
+			$hookContainer = MediaWikiServices::getInstance()->getHookContainer();
+			$hookContainer->run( 'SkinTweekiAdditionalBodyClasses', [ $sk, &$additionalBodyClasses ] );
 
 			if( count( $additionalBodyClasses ) > 0 ) {
 				$bodyAttrs['class'] = $bodyAttrs['class'] . ' ' . preg_replace( "/[^a-zA-Z0-9_\s-]/", "", implode( " ", $additionalBodyClasses ) );

--- a/includes/TweekiTemplate.php
+++ b/includes/TweekiTemplate.php
@@ -1258,7 +1258,8 @@ class TweekiTemplate extends BaseTemplate {
 			/* is it a file? */
 			$brandimageTitle = Title::newFromText( $brand );
 			if ( ! is_null( $brandimageTitle ) && $brandimageTitle->exists() ) {
-				$brandimageWikiPage = WikiPage::factory( $brandimageTitle );
+				$wikiPageFactory = MediaWikiServices::getInstance()->getWikiPageFactory();
+				$brandimageWikiPage = $wikiPageFactory->newFromTitle( $brandimageTitle );
 				if ( method_exists( $brandimageWikiPage, 'getFile' ) ) {
 					$brandimage = $brandimageWikiPage->getFile()->getFullUrl();
 					$brand = '<img src="' . $brandimage . '" alt="' . $this->data['sitename'] . '" />';

--- a/includes/TweekiTemplate.php
+++ b/includes/TweekiTemplate.php
@@ -695,7 +695,8 @@ class TweekiTemplate extends BaseTemplate {
 	 * @param $item String
 	 */
 	public function checkVisibility( $item ) {
-		if (
+		$hookContainer = MediaWikiServices::getInstance()->getHookContainer();
+		return (
 			(
 				!$this->checkVisibilitySetting( $item, $this->config->get( 'TweekiSkinHideNonAdvanced' ) ) ||
 				$this->data['advanced'] // not hidden for non-advanced OR advanced
@@ -712,12 +713,8 @@ class TweekiTemplate extends BaseTemplate {
 			&&
 			!$this->checkVisibilityGroups( $item ) // not hidden for all OR user is in exempted group
 			&&
-			false !== Hooks::run( 'SkinTweekiCheckVisibility', [ $this, $item ] ) // not hidden via hook
-		) {
-			return true;
-		}	else {
-			return false;
-		}
+			false !== $hookContainer->run( 'SkinTweekiCheckVisibility', [ $this, $item ] ) // not hidden via hook
+		);
 	}
 
 


### PR DESCRIPTION
As pointed out in #267, `WikiPage::factory` was removed in MediaWiki 1.41. However calls to can easily be replaced with calls to `WikiPageFactory::newFromTitle`.

While fixing this, I noticed warnings because `Hooks::run` was called, which is deprecated since MediaWiki 1.35, and might be removed soon. This also has a new "drop-in replacement" with `HookContainer::run`. So I implemented that fix too.

Closes #267