### PR TITLE
Fixes Class 'ResourceLoaderSkinModule' Not Found Error #734

### DIFF
--- a/skin.json
+++ b/skin.json
@@ -8,7 +8,7 @@
 	"license-name": "GPL-2.0-or-later",
 	"type": "skin",
 	"requires": {
-		"MediaWiki": ">= 1.35.0"
+		"MediaWiki": ">= 1.39.0"
 	},
 	"ConfigRegistry": {
 		"tweeki": "GlobalVarConfig::newInstance"
@@ -51,14 +51,14 @@
 			]
 		},
 		"skins.tweeki.styles": {
-			"class": "ResourceLoaderSkinModule",
+			"class": "MediaWiki\\ResourceLoader\\SkinModule",
 			"position": "top",
 			"styles": {
 				"public/default/css/tweeki.css": {}
 			}
 		},
 		"skins.tweeki.custom.styles": {
-			"class": "ResourceLoaderSkinModule",
+			"class": "MediaWiki\\ResourceLoader\\SkinModule",
 			"position": "top",
 			"styles": {
 				"public/custom/css/custom.css": {}


### PR DESCRIPTION
The alias ResourceLoaderSkinModule was dropped in favor of MediaWiki\ResourceLoader\SkinModule in https://gerrit.wikimedia.org/r/c/mediawiki/core/+/994854

See: https://phabricator.wikimedia.org/T356563