### PR TITLE
Fixed bug with tweekihideexcept parser function.

### DIFF
--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -456,7 +456,7 @@ class TweekiHooks {
 
 		$groups_except = explode( ',', func_get_arg( 1 ) );
 		$userGroupManager = MediaWikiServices::getInstance()->getUserGroupManager();
-		$groups_user = $userGroupManager->getUserEffectiveGroups($parser->getUser());
+		$groups_user = $userGroupManager->getUserEffectiveGroups($parser->getUserIdentity());
 		if( count( array_intersect( $groups_except, $groups_user ) ) == 0 ) {
 			for ( $i = 2; $i < func_num_args(); $i++ ) {
 				if ( in_array ( func_get_arg( $i ), $GLOBALS['wgTweekiSkinHideable'] ) ) {


### PR DESCRIPTION
`$parser->getUser()` no longer exists, the correct function is now `$parser->getUserIdentity()` since MediaWiki 1.36.

https://doc.wikimedia.org/mediawiki-core/master/php/classMediaWiki_1_1Parser_1_1Parser.html#a858f328c3e898e93f7a368a9cf3d1924

I was trying to do `{{#tweekihideexcept:user|sidebar-right}}` but after upgrading from 1.35, I noticed this no longer worked and threw an error instead.