### PR TITLE
Fix 1.44 compatibility

### DIFF
--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -1,8 +1,11 @@
 <?php
 
+use MediaWiki\Html\Html;
+use MediaWiki\Linker\Linker;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Linker\LinkRenderer;
 use MediaWiki\Linker\LinkTarget;
+use MediaWiki\Title\Title;
 
 /**
  * Hooks for Tweeki skin

--- a/includes/TweekiTemplate.php
+++ b/includes/TweekiTemplate.php
@@ -22,8 +22,10 @@
  * @ingroup Skins
  */
 
+use MediaWiki\Linker\Linker;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Session\SessionManager;
+use MediaWiki\Title\Title;
 
 /**
  * QuickTemplate subclass for Vector

--- a/includes/TweekiTemplate.php
+++ b/includes/TweekiTemplate.php
@@ -68,7 +68,7 @@ class TweekiTemplate extends BaseTemplate {
 			}
 		}
 		$this->data['pageLanguage'] =
-			$this->getSkin()->getTitle()->getPageViewLanguage()->getHtmlCode();
+			$this->getSkin()->getTitle()->getPageLanguage()->getHtmlCode();
 
 		//set userStateClass
 		if ( $this->data['loggedin'] ) {

--- a/skin.json
+++ b/skin.json
@@ -8,7 +8,7 @@
 	"license-name": "GPL-2.0-or-later",
 	"type": "skin",
 	"requires": {
-		"MediaWiki": ">= 1.39.0"
+		"MediaWiki": ">= 1.40.0"
 	},
 	"ConfigRegistry": {
 		"tweeki": "GlobalVarConfig::newInstance"


### PR DESCRIPTION
This should make the skin work with MediaWiki 1.44. I haven't tested the skin fully, but pages are now viewable without getting an error.
The MediaWiki requirement has to be raised to 1.40 since the namespaced classes aren't available in versions before that, but are required as of 1.44.