### PR TITLE
Add support for MediaWiki 1.44

### DIFF
--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -1,8 +1,10 @@
 <?php
 
+use MediaWiki\Html\Html;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Linker\LinkRenderer;
 use MediaWiki\Linker\LinkTarget;
+use MediaWiki\Title\Title;
 
 /**
  * Hooks for Tweeki skin

--- a/skin.json
+++ b/skin.json
@@ -8,7 +8,7 @@
 	"license-name": "GPL-2.0-or-later",
 	"type": "skin",
 	"requires": {
-		"MediaWiki": ">= 1.39.0"
+		"MediaWiki": ">= 1.40.0"
 	},
 	"ConfigRegistry": {
 		"tweeki": "GlobalVarConfig::newInstance"


### PR DESCRIPTION
The old Title and Html alias were removed in MW 1.44.

We increase MW combat to MW 1.40.