### PR TITLE
Use namespaced GlobalVarConfig

### DIFF
--- a/skin.json
+++ b/skin.json
@@ -11,7 +11,7 @@
 		"MediaWiki": ">= 1.43.0"
 	},
 	"ConfigRegistry": {
-		"tweeki": "GlobalVarConfig::newInstance"
+		"tweeki": "MediaWiki\\Config\\GlobalVarConfig::newInstance"
 	},
 	"ValidSkinNames": {
 		"tweeki": "Tweeki"


### PR DESCRIPTION
The non-namespaced class alias was deprecated in MW 1.41. See also https://phabricator.wikimedia.org/T402038