### PR TITLE
Fix SMW footer icon offset in vertical footer icon stack

### DIFF
--- a/resources/styles/tweeki/_footer.scss
+++ b/resources/styles/tweeki/_footer.scss
@@ -26,6 +26,10 @@
     li#footer-poweredbyico {
       display: flex;
       flex-direction: column;
+
+      .smw-footer {
+        margin-left: 0;
+      }
     }
   }
 }


### PR DESCRIPTION
Fix SMW footer icon offset in vertical footer icon stack

## Summary

This fixes the Semantic MediaWiki powered-by icon being shifted to the right when Tweeki renders footer icons vertically.

Tweeki stacks the powered-by footer icons with `flex-direction: column`. Semantic MediaWiki adds `.smw-footer { margin-left: 5px; }`, which makes sense in horizontal icon layouts but creates a visible horizontal offset in Tweeki's vertical stack.

The fix scopes the reset to Tweeki's powered-by footer icon stack only, so SMW's footer styling is not changed globally.

## Change

```scss
#footer {
  ul {
    li#footer-poweredbyico {
      display: flex;
      flex-direction: column;

      .smw-footer {
        margin-left: 0;
      }
    }
  }
}
```

## Testing

Not run locally against a full MediaWiki + SMW instance. The CSS selector is scoped to `#footer li#footer-poweredbyico .smw-footer` and only affects the vertical powered-by footer icon stack.
